### PR TITLE
Fix version parsing

### DIFF
--- a/ob-dsq.el
+++ b/ob-dsq.el
@@ -320,7 +320,7 @@ function, so am back-porting it here."
   "Retrieve version of `dsq`."
   (or
   (when-let ((dsq-version-string (shell-command-to-string (format "%s --version" org-babel-dsq-command))))
-    (and (string-match "^dsq \\(.*\\)$" dsq-version-string)
+    (and (string-match "^dsq v?\\(.*\\)$" dsq-version-string)
          (match-string 1 dsq-version-string)))
   (error "Cannot determine version of `dsq`")))
 


### PR DESCRIPTION
In recent version of dsq, the version number is prepended with a "v".

Without it, with dsq v0.22, evaluating a code block return: `version-to-list: Invalid version syntax: ‘v0.22.0’ (must start with a number)`.
